### PR TITLE
Ticket6442 handling of return values 

### DIFF
--- a/libHVCAENx527App/src/HVCAENx527.c
+++ b/libHVCAENx527App/src/HVCAENx527.c
@@ -1273,8 +1273,7 @@ int
 CAENx527SetAllChParVal( HVCRATE *cr, char *pname, void *val)
 {
 	int i, j;
-	int rval;
-	rval = 0;
+	int rval = 0;
 	int nset;
 	int pnum;
 	unsigned long type;

--- a/libHVCAENx527App/src/HVCAENx527.c
+++ b/libHVCAENx527App/src/HVCAENx527.c
@@ -1432,6 +1432,7 @@ CAENx527SetAllChParVal( HVCRATE *cr, char *pname, void *val)
 		}
 #endif	/* CAENHVWrapperVERSION */
 		free( chlist);
+		/* We should not deinit the whole system if we get a strange channel parameter return value
 		if( retval != CAENHV_OK)
 		{
 			cr->connected = 0;
@@ -1442,10 +1443,10 @@ CAENx527SetAllChParVal( HVCRATE *cr, char *pname, void *val)
 			printf("Lost connection to %s@%s: %s (%d)\n", cr->name, cr->IPaddr, CAENHV_GetError(cr->handle), retval);
 			CAENHV_DeinitSystem( cr->handle);
             cr->handle = -1;
-#endif	/* CAENHVWrapperVERSION */
+#endif	// CAENHVWrapperVERSION
 		    busyUnlock(cr->crate);
 			return( 3);
-		}
+		} */
 		busyUnlock(cr->crate);
 	}
 	return( 0);

--- a/libHVCAENx527App/src/HVCAENx527.c
+++ b/libHVCAENx527App/src/HVCAENx527.c
@@ -493,7 +493,7 @@ PDEBUG(1) printf( "DEBUG: InitCrate(): found %d slots, with total of %d channels
 #endif	/* CAENHVWrapperVERSION */
 				if( retval != CAENHV_OK)
 				{
-					return;
+					continue;
 				}
 				parnamelist = (char (*)[MAX_PARAM_NAME])par;
 
@@ -515,7 +515,7 @@ PDEBUG(3) printf( "DEBUG: number of parameters for each channel: %d\n", npar);
 					if( hvch->pplist == NULL)
 					{
 						printf( "InitCrate: Failed to calloc parameter property list.\n");
-						return;
+						continue;
 					}
 					cr->hvchmap[i].hvchan[j] = hvch;
 					hvch->hvcrate = cr;

--- a/libHVCAENx527App/src/HVCAENx527.c
+++ b/libHVCAENx527App/src/HVCAENx527.c
@@ -1240,7 +1240,8 @@ CAENx527GetAllChParVal( HVCRATE *cr, char *pname)
 				}
 				/* this is only called from main scan loop - should we disconnect on all errors, or just use fact
 				   that CAENHV_GetSysProp() will fail and disconnect for us? */
-				else if(retval != CAENHV_OK /*retval == CAENHV_TIMEERR*/ )
+				/* ^ Yes we should 
+				else if(retval != CAENHV_OK) // retval == CAENHV_TIMEERR )
 				{
 					cr->connected = 0;
 #if CAENHVWrapperVERSION / 100 == 2
@@ -1250,9 +1251,9 @@ CAENx527GetAllChParVal( HVCRATE *cr, char *pname)
 					printf("Lost connection to %s@%s: %s (%d)\n", Crate[i].name, Crate[i].IPaddr, CAENHV_GetError(Crate[i].handle), retval);
 					CAENHV_DeinitSystem( cr->handle);
                     cr->handle = -1;
-#endif	/* CAENHVWrapperVERSION */
+#endif	// CAENHVWrapperVERSION
 					rval = 4;
-				}
+				}*/
 				else
 				{
 					rval = 3;

--- a/libHVCAENx527App/src/HVCAENx527.c
+++ b/libHVCAENx527App/src/HVCAENx527.c
@@ -1237,25 +1237,7 @@ CAENx527GetAllChParVal( HVCRATE *cr, char *pname)
 #endif
 						}
 					}
-				}
-				/* this is only called from main scan loop - should we disconnect on all errors, or just use fact
-				   that CAENHV_GetSysProp() will fail and disconnect for us? */
-				/* ^ Yes we should 
-				else if(retval != CAENHV_OK) // retval == CAENHV_TIMEERR )
-				{
-					cr->connected = 0;
-#if CAENHVWrapperVERSION / 100 == 2
-					printf("Lost connection to %s@%s: %s (%d)\n", Crate[i].name, Crate[i].IPaddr, CAENHVGetError(Crate[i].name), retval);
-					CAENHVDeinitSystem( cr->name);
-#else
-					printf("Lost connection to %s@%s: %s (%d)\n", Crate[i].name, Crate[i].IPaddr, CAENHV_GetError(Crate[i].handle), retval);
-					CAENHV_DeinitSystem( cr->handle);
-                    cr->handle = -1;
-#endif	// CAENHVWrapperVERSION
-					rval = 4;
-				}*/
-				else
-				{
+				} else {
 					rval = 3;
 				}
 #if CAENHVWrapperVERSION / 100 == 2
@@ -1432,21 +1414,6 @@ CAENx527SetAllChParVal( HVCRATE *cr, char *pname, void *val)
 		}
 #endif	/* CAENHVWrapperVERSION */
 		free( chlist);
-		/* We should not deinit the whole system if we get a strange channel parameter return value
-		if( retval != CAENHV_OK)
-		{
-			cr->connected = 0;
-#if CAENHVWrapperVERSION / 100 == 2
-			printf("Lost connection to %s@%s: %s (%d)\n", cr->name, cr->IPaddr, CAENHVGetError(cr->name), retval);
-			CAENHVDeinitSystem( cr->name);
-#else
-			printf("Lost connection to %s@%s: %s (%d)\n", cr->name, cr->IPaddr, CAENHV_GetError(cr->handle), retval);
-			CAENHV_DeinitSystem( cr->handle);
-            cr->handle = -1;
-#endif	// CAENHVWrapperVERSION
-		    busyUnlock(cr->crate);
-			return( 3);
-		} */
 		busyUnlock(cr->crate);
 	}
 	return( 0);


### PR DESCRIPTION
## Description of work

- Handle the use of return values from the new version of the CAENHVWrapper library correctly
- Avoid the loss of parameters by not cutting off loops prematurely
- Avoid deinitialising the whole system because of one return value from a channel parameter

https://github.com/ISISComputingGroup/IBEX/issues/6442