### PR TITLE
Added more simulated detectors for system tests

### DIFF
--- a/libHVCAENx527App/src/CAENHVWrapper_sim.cpp
+++ b/libHVCAENx527App/src/CAENHVWrapper_sim.cpp
@@ -7,8 +7,8 @@
 #define CAENHVLIB /* so we get dllexport rather than dllimport on windows in CAENHVWrapper.h */
 #include "CAENHVWrapper.h"
 
-#define NUM_SLOTS 2
-#define NUM_CH 2
+#define NUM_SLOTS 5
+#define NUM_CH 13
 #define BOARDNAME "s1535s"
 
 static unsigned g_call_out = 0;


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/7132.

Increased the number of simulated slots and channels for system tests for `do_sans` `do_trans` system tests as they need slot and channel numbers originally simulated. 

System tests PR: https://github.com/ISISComputingGroup/system_tests/pull/89