### PR TITLE
MuSR caen - add tolerance PVs

### DIFF
--- a/HVCAENx527App/Db/HVCAENx527gbl.db
+++ b/HVCAENx527App/Db/HVCAENx527gbl.db
@@ -184,3 +184,12 @@ record(calc, "$(P):EVNTO_T1:UPDATING")
     field(CALC, "(B!=A?1:0);B:=A")
     field(SCAN, "5 second")
 }
+
+# Global Voltage tolerance in % for determining whether a channel is
+# 'close' to it's voltage setpoint.
+record(ao, "$(P):voltage_tolerance") {
+    field(PREC, "2")
+	field(EGU, "%")
+	field(VAL, "$(VTOL=0)")
+	info(archive, VAL)
+}

--- a/libHVCAENx527App/Db/HVCAENx527ch.tpl
+++ b/libHVCAENx527App/Db/HVCAENx527ch.tpl
@@ -634,3 +634,11 @@ alias("$(PSNAME):SIM:$(CHANNUM):pwdnmode","$(PSNAME):SIM:$(CHANNUM):pwdnmode:fbk
 alias("$(PSNAME):SIM:$(CHANNUM):tripint","$(PSNAME):SIM:$(CHANNUM):tripint:fbk")
 alias("$(PSNAME):SIM:$(CHANNUM):tripext","$(PSNAME):SIM:$(CHANNUM):tripext:fbk")
 
+record(calc, "$(PSNAME):$(CHANNUM):intol") {
+    field(INPA, "$(PSNAME):$(CHANNUM):v0set:fbk CP MSS")
+    field(INPB, "$(PSNAME):$(CHANNUM):vmon CP MSS")
+	field(INPC, "$(P):voltage_tolerance CP MSS")
+	field(CALC, "(B>=(1-(C/100))*A) && (B<=(1+(C/100))*A)")
+	info(archive, VAL)
+}
+

--- a/libHVCAENx527App/Db/HVCAENx527ch.tpl
+++ b/libHVCAENx527App/Db/HVCAENx527ch.tpl
@@ -638,6 +638,8 @@ record(calc, "$(PSNAME):$(CHANNUM):intol") {
     field(INPA, "$(PSNAME):$(CHANNUM):v0set:fbk CP MSS")
     field(INPB, "$(PSNAME):$(CHANNUM):vmon CP MSS")
 	field(INPC, "$(P):voltage_tolerance CP MSS")
+	# Check that the actual voltage (vmon, B) lies in the range (100%-tolerance)*vset to (100%+tolerance)*vset
+	# (i.e. the actual voltage is within tolerance % of the setpoint)
 	field(CALC, "(B>=(1-(C/100))*A) && (B<=(1+(C/100))*A)")
 	info(archive, VAL)
 }


### PR DESCRIPTION
Adds voltage tolerance PVs for MuSR - to be consumed by MuSR's `custom_records.db`

For https://github.com/ISISComputingGroup/IBEX/issues/6404